### PR TITLE
Remove Concrete IO

### DIFF
--- a/src/main/scala/com/minosiants/pencil/ContentTypeFinder.scala
+++ b/src/main/scala/com/minosiants/pencil/ContentTypeFinder.scala
@@ -21,19 +21,20 @@ import java.io.InputStream
 import protocol._
 import data._
 
-import cats.effect.IO
+import cats.implicits._
+import cats.effect.Sync
 import org.apache.tika.Tika
 
 object ContentTypeFinder {
 
   lazy val tika = new Tika()
 
-  def findType(is: InputStream): IO[ContentType] =
-    IO {
+  def findType[F[_]: Sync](is: InputStream): F[ContentType] =
+    Sync[F].delay {
       val ct = tika.detect(is)
       ContentType
         .findType(ct)
         .getOrElse(ContentType.`application/octet-stream`)
-    }.handleErrorWith(Error.tikaException("Unable to read input stream"))
+    }.handleErrorWith(Error.tikaException[F, ContentType]("Unable to read input stream"))
 
 }

--- a/src/main/scala/com/minosiants/pencil/LiteralSyntaxMacros.scala
+++ b/src/main/scala/com/minosiants/pencil/LiteralSyntaxMacros.scala
@@ -79,7 +79,7 @@ object LiteralSyntaxMacros {
     singlePartInterpolator(c)(
       args,
       "Attachment",
-      Attachment.fromString(_).isRight,
+      Attachment.fromString[cats.effect.IO](_).unsafeRunSync.isRight, // We're touching files in macros?
       s => c.universe.reify(Attachment.unsafeFromString(s.splice))
     )
 

--- a/src/main/scala/com/minosiants/pencil/Request.scala
+++ b/src/main/scala/com/minosiants/pencil/Request.scala
@@ -3,4 +3,4 @@ package com.minosiants.pencil
 import cats.effect.Blocker
 import com.minosiants.pencil.data.Email
 
-final case class Request(email: Email, socket: SmtpSocket, blocker: Blocker)
+final case class Request[F[_]](email: Email, socket: SmtpSocket[F], blocker: Blocker)

--- a/src/main/scala/com/minosiants/pencil/Smtp.scala
+++ b/src/main/scala/com/minosiants/pencil/Smtp.scala
@@ -17,15 +17,12 @@
 package com.minosiants.pencil
 
 import cats.data.Kleisli
-import cats.effect.IO
+import cats.effect.Sync
 import protocol._
 import data._
-import cats.syntax.flatMap._
-import cats.syntax.show._
-import cats.syntax.traverse._
-import cats.syntax.functor._
-import cats.instances.list._
 
+import cats._
+import cats.implicits._
 import scala.Function._
 import com.minosiants.pencil.data.{ Email, Mailbox }
 import Header._
@@ -40,67 +37,76 @@ import fs2.io.file.readAll
 
 object Smtp {
 
-  def apply[A](run: Request => IO[A]): Smtp[A] =
-    Kleisli(req => run(req))
+  // Used for easier type inference
+  def apply[F[_]]: SmtpPartiallyApplied[F] =
+    new SmtpPartiallyApplied[F]{}
 
-  def pure[A](a: A): Smtp[A] =
+  class SmtpPartiallyApplied[F[_]]{
+    def apply[A](run: Request[F] => F[A]): Smtp[F, A] = 
+      Kleisli(req => run(req))
+  }
+
+  def pure[F[_]: Applicative, A](a: A): Smtp[F, A] =
     Kleisli.pure(a)
 
-  def liftF[A](a: IO[A]): Smtp[A] =
+  def liftF[F[_], A](a: F[A]): Smtp[F, A] =
     Kleisli.liftF(a)
 
-  def local[A](f: Request => Request)(smtp: Smtp[A]): Smtp[A] =
+  def local[F[_], A](f: Request[F] => Request[F])(smtp: Smtp[F, A]): Smtp[F, A] =
     Kleisli.local(f)(smtp)
 
-  def write(run: Email => Command): Smtp[Unit] = Smtp { req =>
+  def write[F[_]](run: Email => Command): Smtp[F, Unit] = Smtp[F] { req =>
     req.socket.write(run(req.email))
   }
 
-  def ask: Smtp[Request] = Kleisli.ask[IO, Request]
+  def ask[F[_]: Applicative]: Smtp[F, Request[F]] = Kleisli.ask[F, Request[F]]
 
-  def read(): Smtp[Replies] = Smtp(_.socket.read()).flatMapF(processErrors)
+  def processErrors[F[_]: ApplicativeError[*[_], Throwable]](replies: Replies): F[Replies] =
+    if (replies.success) Applicative[F].pure(replies) 
+    else Error.smtpError[F, Replies](replies.show)
 
-  def processErrors(replies: Replies): IO[Replies] =
-    if (replies.success) IO(replies) else Error.smtpError(replies.show)
+  def read[F[_]: MonadError[*[_], Throwable]](): Smtp[F, Replies] = 
+    Smtp[F](_.socket.read()).flatMapF(processErrors[F])
 
-  def command1(run: Email => Command): Smtp[Replies] = write(run) >> read()
+  def command1[F[_]: MonadError[*[_], Throwable]](run: Email => Command): Smtp[F, Replies] = 
+    write[F](run).flatMap(_ => read[F]())
 
-  def command(c: Command): Smtp[Replies] = command1(const(c))
+  def command[F[_]: MonadError[*[_], Throwable]](c: Command): Smtp[F, Replies] = command1(const(c))
 
-  def init(): Smtp[Replies] = read
+  def init[F[_]: MonadError[*[_], Throwable]](): Smtp[F, Replies] = read[F]
 
-  def ehlo(): Smtp[Replies] = command(Ehlo("pencil"))
+  def ehlo[F[_]: MonadError[*[_], Throwable]](): Smtp[F, Replies] = command(Ehlo("pencil"))
 
-  def mail(): Smtp[Replies] = command1(m => Mail(m.from.box))
+  def mail[F[_]: MonadError[*[_], Throwable]](): Smtp[F, Replies] = command1(m => Mail(m.from.box))
 
-  def rcpt(): Smtp[List[Replies]] = Smtp { req =>
-    val rcptCommand = (m: Mailbox) => command(Rcpt(m)).run(req)
+  def rcpt[F[_]: MonadError[*[_], Throwable]](): Smtp[F, List[Replies]] = Smtp[F] { req =>
+    val rcptCommand = (m: Mailbox) => command[F](Rcpt(m)).run(req)
     req.email.recipients.toList.traverse(rcptCommand)
   }
 
-  def data(): Smtp[Replies] = command(Data)
+  def data[F[_]: MonadError[*[_], Throwable]](): Smtp[F, Replies] = command(Data)
 
-  def rset(): Smtp[Replies] = command(Rset)
+  def rset[F[_]: MonadError[*[_], Throwable]](): Smtp[F, Replies] = command(Rset)
 
-  def vrfy(str: String): Smtp[Replies] = command(Vrfy(str))
+  def vrfy[F[_]: MonadError[*[_], Throwable]](str: String): Smtp[F, Replies] = command(Vrfy(str))
 
-  def noop(): Smtp[Replies] = command(Noop)
+  def noop[F[_]: MonadError[*[_], Throwable]](): Smtp[F, Replies] = command(Noop)
 
-  def quit(): Smtp[Replies] = command(Quit)
+  def quit[F[_]: MonadError[*[_], Throwable]](): Smtp[F, Replies] = command(Quit)
 
-  def text(txt: String): Smtp[Unit] = write(const(Text(txt)))
+  def text[F[_]](txt: String): Smtp[F, Unit] = write(const(Text(txt)))
 
-  def startTls(): Smtp[Replies] = command(StartTls)
+  def startTls[F[_]: MonadError[*[_], Throwable]](): Smtp[F, Replies] = command(StartTls)
 
-  def authLogin(): Smtp[Replies] =
+  def authLogin[F[_]: MonadError[*[_], Throwable]](): Smtp[F, Replies] =
     for {
-      rep <- command(AuthLogin)
-      _   <- checkReplyFor(`334`, rep)
+      rep <- command[F](AuthLogin)
+      _   <- checkReplyFor[F](`334`, rep)
     } yield rep
 
-  def checkReplyFor(code: Code, replies: Replies): Smtp[Replies] =
+  def checkReplyFor[F[_]: ApplicativeError[*[_], Throwable]](code: Code, replies: Replies): Smtp[F, Replies] =
     liftF(
-      IO.fromEither(
+      ApplicativeError[F, Throwable].fromEither(
         Either.cond(
           replies.hasCode(code),
           replies,
@@ -109,42 +115,41 @@ object Smtp {
         )
       )
     )
-  def login(credentials: Credentials): Smtp[Unit] =
+  def login[F[_]: MonadError[*[_], Throwable]](credentials: Credentials): Smtp[F, Unit] =
     for {
-      _ <- authLogin()
-      ru <- command(
+      _ <- authLogin[F]()
+      ru <- command[F](
         Text(s"${credentials.username.show.toBase64} ${Command.end}")
       )
-      _ <- checkReplyFor(`334`, ru)
-      rp <- command(
+      _ <- checkReplyFor[F](`334`, ru)
+      rp <- command[F](
         Text(s"${credentials.password.show.toBase64} ${Command.end}")
       )
-      _ <- checkReplyFor(`235`, rp)
+      _ <- checkReplyFor[F](`235`, rp)
     } yield ()
 
-  def endEmail(): Smtp[Replies] = Smtp { req =>
+  def endEmail[F[_]: MonadError[*[_], Throwable]](): Smtp[F,Replies] = Smtp[F] { req =>
     val p = req.email match {
-      case TextEmail(_, _, _, _, _, _) => text(Command.endEmail) >> read
+      case TextEmail(_, _, _, _, _, _) => text[F](Command.endEmail).flatMap(_ => read[F])
       case _ =>
         for {
-          _ <- boundary(true)
-          _ <- text(Command.endEmail)
-          r <- read()
+          _ <- boundary[F](true)
+          _ <- text[F](Command.endEmail)
+          r <- read[F]()
         } yield r
     }
     p.run(req)
-
   }
 
-  def asciiBody(): Smtp[Replies] = Smtp { req =>
+  def asciiBody[F[_]: MonadError[*[_], Throwable]](): Smtp[F, Replies] = Smtp[F] { req =>
     req.email match {
       case TextEmail(_, _, _, _, _, Some(Ascii(body))) =>
-        (text(s"$body ${Command.end}") >> endEmail()).run(req)
-      case _ => Error.smtpError("Body is not ascii")
+        (text(s"$body ${Command.end}").flatMap(_ => endEmail[F]())).run(req)
+      case _ => Error.smtpError[F, Replies]("Body is not ascii")
     }
   }
 
-  def subjectHeader(): Smtp[Option[Unit]] = Smtp { req =>
+  def subjectHeader[F[_]: MonadError[*[_], Throwable]](): Smtp[F, Option[Unit]] = Smtp[F] { req =>
     req.email match {
       case TextEmail(_, _, _, _, Some(Subject(sub)), _) =>
         text(s"Subject: $sub ${Command.end}").run(req).map(Some(_))
@@ -152,139 +157,136 @@ object Smtp {
         text(s"Subject: =?utf-8?b?${sub.toBase64}?= ${Command.end}")
           .run(req)
           .map(Some(_))
-      case _ => IO(None)
+      case _ => Applicative[F].pure(None)
     }
 
   }
 
-  def fromHeader(): Smtp[Unit] = Smtp { req =>
+  def fromHeader[F[_]](): Smtp[F, Unit] = Smtp[F] { req =>
     text(s"From: ${req.email.from.show} ${Command.end}").run(req)
   }
-  def toHeader(): Smtp[Unit] = Smtp { req =>
+  def toHeader[F[_]](): Smtp[F, Unit] = Smtp[F] { req =>
     text(s"To: ${req.email.to.show} ${Command.end}").run(req)
   }
 
-  def ccHeader(): Smtp[Option[Unit]] = Smtp { req =>
+  def ccHeader[F[_]: Applicative](): Smtp[F, Option[Unit]] = Smtp[F] { req =>
     req.email.cc match {
       case Some(v) =>
         text(s"Cc: ${v.show} ${Command.end}").run(req).map(Some(_))
-      case None => IO(None)
+      case None => Applicative[F].pure(None)
     }
   }
 
-  def bccHeader(): Smtp[Option[Unit]] = Smtp { req =>
+  def bccHeader[F[_]: Applicative](): Smtp[F, Option[Unit]] = Smtp[F] { req =>
     req.email.bcc match {
       case Some(v) =>
         text(s"Bcc: ${v.show} ${Command.end}").run(req).map(Some(_))
-      case None => IO(None)
+      case None => Applicative[F].pure(None)
     }
   }
-  def mainHeaders(): Smtp[Unit] =
+  def mainHeaders[F[_]: MonadError[*[_], Throwable]](): Smtp[F, Unit] =
     for {
-      _ <- fromHeader()
-      _ <- toHeader()
-      _ <- ccHeader()
-      _ <- bccHeader()
-      _ <- subjectHeader()
+      _ <- fromHeader[F]()
+      _ <- toHeader[F]()
+      _ <- ccHeader[F]()
+      _ <- bccHeader[F]()
+      _ <- subjectHeader[F]()
     } yield ()
 
-  def mimeHeader(): Smtp[Unit] = {
+  def mimeHeader[F[_]](): Smtp[F, Unit] = {
     text(s"${headerShow.show(`MIME-Version`())} ${Command.end}")
   }
 
-  def contentTypeHeader(
+  def contentTypeHeader[F[_]](
       ct: `Content-Type`
-  ): Smtp[Unit] = text(s"${headerShow.show(ct)} ${Command.end}")
+  ): Smtp[F, Unit] = text(s"${headerShow.show(ct)} ${Command.end}")
 
-  def contentTransferEncoding(encoding: Encoding): Smtp[Unit] =
+  def contentTransferEncoding[F[_]](encoding: Encoding): Smtp[F, Unit] =
     text(
       s"${headerShow.show(`Content-Transfer-Encoding`(encoding))} ${Command.end}"
     )
 
-  def boundary(isFinal: Boolean = false): Smtp[Unit] = Smtp { req =>
+  def boundary[F[_]: ApplicativeError[*[_], Throwable]](isFinal: Boolean = false): Smtp[F, Unit] = Smtp[F] { req =>
     req.email match {
       case e @ MimeEmail(_, _, _, _, _, _, _, Boundary(b)) =>
         val end = if (isFinal) "--" else ""
         if (e.isMultipart)
           text(s"--$b$end ${Command.end}").run(req)
         else
-          IO(())
-      case TextEmail(_, _, _, _, _, _) => Error.smtpError("not mime")
+          Applicative[F].unit
+      case TextEmail(_, _, _, _, _, _) => Error.smtpError[F, Unit]("not mime")
     }
   }
 
-  def mimePart(mech: Encoding, ct: `Content-Type`): Smtp[Unit] =
+  def mimePart[F[_]: MonadError[*[_], Throwable]](mech: Encoding, ct: `Content-Type`): Smtp[F, Unit] =
     for {
-      _ <- boundary()
-      _ <- contentTypeHeader(ct)
-      _ <- contentTransferEncoding(mech)
+      _ <- boundary[F]()
+      _ <- contentTypeHeader[F](ct)
+      _ <- contentTransferEncoding[F](mech)
       _ <- text(Command.end)
     } yield ()
 
-  def multipart(): Smtp[Unit] = Smtp { req =>
+  def multipart[F[_]: ApplicativeError[*[_], Throwable]](): Smtp[F, Unit] = Smtp[F] { req =>
     req.email match {
       case m @ MimeEmail(_, _, _, _, _, _, _, Boundary(b)) if m.isMultipart =>
         contentTypeHeader(
           `Content-Type`(`multipart/mixed`, Map("boundary" -> b))
         ).run(req)
-      case MimeEmail(_, _, _, _, _, _, _, _) => IO(())
-      case _                                 => Error.smtpError("Does not support multipart")
+      case MimeEmail(_, _, _, _, _, _, _, _) => Applicative[F].unit
+      case _                                 => Error.smtpError[F, Unit]("Does not support multipart")
     }
 
   }
-  def mimeBody(): Smtp[Unit] = Smtp { req =>
+  def mimeBody[F[_]: MonadError[*[_], Throwable]](): Smtp[F, Unit] = Smtp[F] { req =>
     req.email match {
       case MimeEmail(_, _, _, _, _, Some(Ascii(body)), _, _) =>
-        (mimePart(
+        (mimePart[F](
           `7bit`,
           `Content-Type`(`text/plain`, Map("charset" -> "US-ASCII"))
-        ) >> text(s"$body ${Command.end}")).run(req)
+        ).flatMap(_ => text(s"$body ${Command.end}"))).run(req)
 
       case MimeEmail(_, _, _, _, _, Some(Html(body)), _, _) =>
-        (mimePart(
+        (mimePart[F](
           `base64`,
           `Content-Type`(`text/html`, Map("charset" -> "UTF-8"))
-        ) >> text(s"${body.toBase64} ${Command.end}")).run(req)
+        ).flatMap(_ => text(s"${body.toBase64} ${Command.end}"))).run(req)
 
       case MimeEmail(_, _, _, _, _, Some(Utf8(body)), _, _) =>
-        (mimePart(
+        (mimePart[F](
           `base64`,
           `Content-Type`(`text/plain`, Map("charset" -> "UTF-8"))
-        ) >> text(s"${body.toBase64} ${Command.end}")).run(req)
+        ).flatMap(_ => text(s"${body.toBase64} ${Command.end}"))).run(req)
 
-      case _ => Error.smtpError("not mime email")
+      case _ => Error.smtpError[F, Unit]("not mime email")
     }
 
   }
 
-  import scala.concurrent.ExecutionContext.Implicits.global
-  implicit val ioContextShift: ContextShift[IO] = IO.contextShift(global)
+  def attachments[F[_]: Sync: ContextShift](): Smtp[F, Unit] = {
+    Smtp[F] { req =>
+      req.email match {
+        case TextEmail(_, _, _, _, _, _) =>
+          Error.smtpError[F, Unit]("attachments not supported")
+        case MimeEmail(_, _, _, _, _, _, attach, _) =>
+          val result = attach.map { a =>
+            for {
+              ct <- Files.inputStream[F](a.file).use(ContentTypeFinder.findType[F])
+              _ <- mimePart[F](
+                `base64`,
+                `Content-Type`(ct, Map("name" -> a.file.getFileName.toString))
+              ).run(req)
+              _ <- readAll[F](a.file, req.blocker, 1024)
+                .through(fs2.text.base64Encode[F])
+                .evalMap { part =>
+                  text[F](s"$part ${Command.end}").run(req)
+                }
+                .compile
+                .drain
 
-  def attachments(): Smtp[Unit] = Smtp { req =>
-    req.email match {
-      case TextEmail(_, _, _, _, _, _) =>
-        Error.smtpError("attachments not supported")
-      case MimeEmail(_, _, _, _, _, _, attach, _) =>
-        val result = attach.map { a =>
-          val res = Files.inputStream(a.file)
-          for {
-            ct <- res.use(ContentTypeFinder.findType)
-            _ <- mimePart(
-              `base64`,
-              `Content-Type`(ct, Map("name" -> a.file.getFileName.toString))
-            ).run(req)
-            _ <- readAll[IO](a.file, req.blocker, 1024)
-              .through(fs2.text.base64Encode)
-              .evalMap { part =>
-                text(s"$part ${Command.end}").run(req)
-              }
-              .compile
-              .drain
-
-          } yield ()
-        }
-
-        result.sequence.as(())
+            } yield ()
+          }
+          result.sequence.as(())
+      }
     }
   }
 

--- a/src/main/scala/com/minosiants/pencil/data/Errors.scala
+++ b/src/main/scala/com/minosiants/pencil/data/Errors.scala
@@ -16,8 +16,8 @@
 
 package com.minosiants.pencil.data
 
-import cats.Show
-import cats.effect.IO
+import cats._
+// import cats.effect.IO
 
 import scala.util.control.NoStackTrace
 
@@ -41,20 +41,20 @@ object Error {
     case TikaException(msg)       => s"Tika exception: $msg"
   }
 
-  def smtpError[A](msg: String): IO[A] =
-    IO.raiseError[A](SmtpError(msg))
+  def smtpError[F[_]: ApplicativeError[*[_], Throwable], A](msg: String): F[A] =
+    ApplicativeError[F, Throwable].raiseError[A](SmtpError(msg))
 
-  def authError[A](msg: String): IO[A] =
-    IO.raiseError[A](AuthError(msg))
+  def authError[F[_]: ApplicativeError[*[_], Throwable], A](msg: String): F[A] =
+    ApplicativeError[F, Throwable].raiseError[A](AuthError(msg))
 
-  def unableCloseResource[A](msg: String): IO[A] =
-    IO.raiseError(UnableCloseResource(msg))
+  def unableCloseResource[F[_]: ApplicativeError[*[_], Throwable],A](msg: String): F[A] =
+    ApplicativeError[F, Throwable].raiseError(UnableCloseResource(msg))
 
-  def resourceNotFound[A](msg: String): IO[A] =
-    IO.raiseError(ResourceNotFound(msg))
+  def resourceNotFound[F[_]: ApplicativeError[*[_], Throwable],A](msg: String): F[A] =
+    ApplicativeError[F, Throwable].raiseError(ResourceNotFound(msg))
 
-  def tikaException[A](msg: String)(e: Throwable): IO[A] = {
+  def tikaException[F[_]: ApplicativeError[*[_], Throwable],A](msg: String)(e: Throwable): F[A] = {
     val m = if (e.getMessage != null) s"Message: ${e.getMessage}" else ""
-    IO.raiseError(TikaException(s"$msg $m"))
+    ApplicativeError[F, Throwable].raiseError(TikaException(s"$msg $m"))
   }
 }

--- a/src/main/scala/com/minosiants/pencil/package.scala
+++ b/src/main/scala/com/minosiants/pencil/package.scala
@@ -17,13 +17,12 @@
 package com.minosiants
 
 import cats.data.Kleisli
-import cats.effect.IO
 import com.minosiants.pencil.syntax.LiteralsSyntax
 import scodec.bits.{ BitVector, ByteVector }
 
 package object pencil extends LiteralsSyntax {
 
-  type Smtp[A] = Kleisli[IO, Request, A]
+  type Smtp[F[_], A] = Kleisli[F, Request[F], A]
 
   val CRLF: ByteVector = ByteVector("\r\n".getBytes)
 

--- a/src/test/scala/com/minosiants/pencil/ContentTypeFinderSpec.scala
+++ b/src/test/scala/com/minosiants/pencil/ContentTypeFinderSpec.scala
@@ -23,10 +23,10 @@ class ContentTypeFinderSpec extends Specification with ScalaCheck {
     "not find file" in {
       val f = Paths.get("files/!!!jpeg-sample.jpg")
       Files
-        .inputStream(f)
+        .inputStream[IO](f)
         .use { is =>
           ContentTypeFinder
-            .findType(is)
+            .findType[IO](is)
         }
         .attempt
         .unsafeRunSync() must beLeft(Error.ResourceNotFound(f.toString))
@@ -44,10 +44,10 @@ object ContentTypeFinderSpec {
       path: Path
   ): IO[ContentType] = {
     Files
-      .inputStream(path)
+      .inputStream[IO](path)
       .use { is =>
         ContentTypeFinder
-          .findType(is)
+          .findType[IO](is)
       }
 
   }

--- a/src/test/scala/com/minosiants/pencil/SmtpIntegrationSpec.scala
+++ b/src/test/scala/com/minosiants/pencil/SmtpIntegrationSpec.scala
@@ -24,7 +24,7 @@ class SmtpIntegrationSpec extends SpecificationLike with CatsIO {
         .use { blocker =>
           SocketGroup[IO](blocker).use { sg =>
             TLSContext.system[IO](blocker).flatMap { tls =>
-              val client = Client()(blocker, sg, tls)
+              val client = Client[IO]()(blocker, sg, tls)
               client.send(email)
             }
 


### PR DESCRIPTION
Built on top of #13 

This switches from Concrete IO to an F bound.

Type Inference is worse, but I tried to make it as nice as I could. Could likely improve my creating a partially applied instance with the F algebras `Smtp[F].xyz` like I did for apply but with all the individual methods.

The macros are actually looking at the files for their attachments in the macros. I got it back to working as it was originally but it makes me uncomfortable. As it won't necessarily be present on the target computer and it bypasses the effect unsafely so I'm not sure that macro is actually safe.