### PR TITLE
Allowing UTF-8 characters in the name of attachments

### DIFF
--- a/src/main/scala/com/minosiants/pencil/LiteralSyntaxMacros.scala
+++ b/src/main/scala/com/minosiants/pencil/LiteralSyntaxMacros.scala
@@ -81,7 +81,7 @@ object LiteralSyntaxMacros {
       "Attachment",
       Attachment
         .fromString[cats.effect.IO](_)
-        .unsafeRunSync
+        .unsafeRunSync()
         .isRight, // We're touching files in macros?
       s => c.universe.reify(Attachment.unsafeFromString(s.splice))
     )

--- a/src/main/scala/com/minosiants/pencil/Smtp.scala
+++ b/src/main/scala/com/minosiants/pencil/Smtp.scala
@@ -69,13 +69,13 @@ object Smtp {
     if (replies.success) Applicative[F].pure(replies)
     else Error.smtpError[F, Replies](replies.show)
 
-  def read[F[_]: MonadError[*[_], Throwable]](): Smtp[F, Replies] =
+  def read[F[_]: MonadError[*[_], Throwable]]: Smtp[F, Replies] =
     Smtp[F](_.socket.read()).flatMapF(processErrors[F])
 
   def command1[F[_]: MonadError[*[_], Throwable]](
       run: Email => Command
   ): Smtp[F, Replies] =
-    write[F](run).flatMap(_ => read[F]())
+    write[F](run).flatMap(_ => read[F])
 
   def command[F[_]: MonadError[*[_], Throwable]](c: Command): Smtp[F, Replies] =
     command1(const(c))
@@ -158,7 +158,7 @@ object Smtp {
           for {
             _ <- boundary[F](true)
             _ <- text[F](Command.endEmail)
-            r <- read[F]()
+            r <- read[F]
           } yield r
       }
       p.run(req)

--- a/src/main/scala/com/minosiants/pencil/Smtp.scala
+++ b/src/main/scala/com/minosiants/pencil/Smtp.scala
@@ -319,7 +319,7 @@ object Smtp {
                 .use(ContentTypeFinder.findType[F])
               _ <- mimePart[F](
                 `base64`,
-                `Content-Type`(ct, Map("name" -> a.file.getFileName.toString))
+                `Content-Type`(ct, Map("name" -> s"=?utf-8?b?${a.file.getFileName.toString.toBase64}?="))
               ).run(req)
               _ <- readAll[F](a.file, req.blocker, 1024)
                 .through(fs2.text.base64Encode[F])

--- a/src/main/scala/com/minosiants/pencil/package.scala
+++ b/src/main/scala/com/minosiants/pencil/package.scala
@@ -28,7 +28,7 @@ package object pencil extends LiteralsSyntax {
 
   val CRLF: ByteVector = ByteVector("\r\n".getBytes)
 
-  implicit class ExtraStringOps(str: String) {
+  implicit class ExtraStringOps(private val str: String) extends AnyVal{
     def toBase64: String         = toBitVector.toBase64
     def toBitVector: BitVector   = BitVector(str.getBytes(StandardCharsets.UTF_8))
     def toByteVector: ByteVector = toBitVector.bytes

--- a/src/main/scala/com/minosiants/pencil/protocol/Header.scala
+++ b/src/main/scala/com/minosiants/pencil/protocol/Header.scala
@@ -39,8 +39,8 @@ object Header {
     case `MIME-Version`(value) => s"MIME-Version: $value"
     case `Content-Type`(ct, params) =>
       val values = params
-        .foldRight(List.empty[String]) { (item, acc) =>
-          acc :+ s"${item._1}=${item._2}"
+        .foldLeft(List.empty[String]) { (acc, item) =>
+          s"${item._1}=${item._2}" :: acc
         }
         .mkString(";")
       s"Content-Type: ${ct.show}; $values"

--- a/src/test/scala/com/minosiants/pencil/SmtpSpec.scala
+++ b/src/test/scala/com/minosiants/pencil/SmtpSpec.scala
@@ -293,7 +293,7 @@ class SmtpSpec extends SmtpBaseSpec {
     result.map(_._2) must beRight(
       List(
         s"--${email.boundary.value}${Command.end}",
-        s"Content-Type: image/png; name=${attachment.file.getFileName.toString}${Command.end}",
+        s"Content-Type: image/png; name==?utf-8?b?${attachment.file.getFileName.toString.toBase64}?=${Command.end}",
         s"Content-Transfer-Encoding: base64${Command.end}",
         s"${Command.end}"
       ) ++ encodedFile.flatMap(SmtpSpec.lines)


### PR DESCRIPTION
Fixes #22 

After playing a while with the code I found that strange sequence of characters on the `Subject` so I gave it a try and it seems to work, I could send a file named `test-ñÁçàôëāã.txt`
But, I am not sure if that is the best way to solve the issue, or if some of those characters are unnecessary.

-----

The second commit includes some minor fixes to the code, but are completely optional to the fix of the bug.
So, if you do not like them we can just revert that commit before merging.