### PR TITLE
Add support for multipart/alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,18 @@ val email = Email.mime(
      Body.Utf8("hi there")
 ) + attachment"path/to/file"
 ```
+
+#### Create mime email
+
+```scala
+val email = Email.mime(
+     from"user1@mydomain.tld",
+     to"user1@example.com",
+     subject"привет",
+     Body.Alternative(List(Body.Utf8("hi there3"), Body.Ascii("hi there2")))
+)
+```
+
 #### Send email
 
 ```scala

--- a/src/main/scala/pencil/data/Body.scala
+++ b/src/main/scala/pencil/data/Body.scala
@@ -16,8 +16,29 @@
 
 package pencil.data
 
+import cats.syntax.option.*
+import pencil.data.Body.{Alternative, Ascii, Html, Utf8}
+
+import scala.Function.const
+
 enum Body:
-  def value: String
   case Ascii(value: String)
   case Html(value: String)
   case Utf8(value: String)
+  case Alternative(bodies: List[Body])
+  def body: Option[String] = fold(_.value.some, _.value.some, _.value.some, const(None))
+  def ascii: Option[Ascii] = fold(_.some, const(None), const(None), const(None))
+  def html: Option[Html] = fold(const(None), _.some, const(None), const(None))
+  def utf8: Option[Utf8] = fold(const(None), const(None), _.some, const(None))
+  def alternative: Option[Alternative] = fold(const(None), const(None), const(None), _.some)
+  def isAlternative: Boolean = alternative.isDefined
+  def fold[A](
+      ascii: Ascii => A,
+      html: Html => A,
+      utf8: Utf8 => A,
+      alternative: Alternative => A
+  ): A = this match
+    case a @ Ascii(_)       => ascii(a)
+    case h @ Html(_)        => html(h)
+    case u @ Utf8(_)        => utf8(u)
+    case a @ Alternative(_) => alternative(a)

--- a/src/main/scala/pencil/data/Email.scala
+++ b/src/main/scala/pencil/data/Email.scala
@@ -129,7 +129,9 @@ final case class Email(
     * @return
     *   \- `true` it is a mutlipart email.
     */
-  def isMultipart: Boolean = emailType match
+  def isMultipart: Boolean = hasAttachmets || body.exists(_.isAlternative)
+
+  def hasAttachmets: Boolean = emailType match
     case EmailType.Text       => false
     case EmailType.Mime(_, a) => a.nonEmpty
 

--- a/src/main/scala/pencil/protocol/CommandCodec.scala
+++ b/src/main/scala/pencil/protocol/CommandCodec.scala
@@ -34,7 +34,7 @@ final case class CommandCodec() extends Codec[Command] {
             DecodeResult(Ehlo(domain), BitVector.empty)
           }
         case "MAIL" =>
-          summon[Codec[Mailbox]].decode(rest.drop(6*8)).map { case DecodeResult(email, _) =>
+          summon[Codec[Mailbox]].decode(rest.drop(6 * 8)).map { case DecodeResult(email, _) =>
             DecodeResult(Mail(email), BitVector.empty)
           }
         case "RCPT" =>

--- a/src/test/scala/pencil/SmtpBaseSpec.scala
+++ b/src/test/scala/pencil/SmtpBaseSpec.scala
@@ -84,5 +84,3 @@ trait SmtpBaseSpec extends SpecificationLike with LiteralsSyntax:
           )
         )
     }.attempt.unsafeRunSync()
-
-

--- a/src/test/scala/pencil/SmtpSpec.scala
+++ b/src/test/scala/pencil/SmtpSpec.scala
@@ -94,7 +94,7 @@ class SmtpSpec extends SmtpBaseSpec {
       result.map(_._2) must beRight(
         beEqualTo(
           List(
-            s"${email.body.get.value}${Command.end}",
+            s"${email.body.flatMap(_.body).get}${Command.end}",
             s"${Command.endEmail}"
           )
         )

--- a/src/test/scala/pencil/SmtpSpec2.scala
+++ b/src/test/scala/pencil/SmtpSpec2.scala
@@ -32,6 +32,6 @@ object SmtpSpec2 extends LiteralsSyntax:
     from"kaspar minosyants<user1@mydomain.tld>",
     to"pencil <pencil@mail.pencil.com>",
     subject"привет",
-    Body.Utf8("hi there")
-    //  List(attachment"files/jpeg-sample.jpg")
+    Body.Utf8("hi there"),
+    List(attachment"/home/kaspar/stuff/sources/pencil/src/test/resources/files/jpeg-sample.jpg")
   )

--- a/src/test/scala/pencil/protocol/ProtocolGens.scala
+++ b/src/test/scala/pencil/protocol/ProtocolGens.scala
@@ -21,8 +21,8 @@ trait ProtocolGens extends EmailGens {
     command <- Gen.oneOf(
       List[Command](
         Ehlo(domain),
-        Mail(box.copy(name=None)),
-        Rcpt(box.copy(name=None)),
+        Mail(box.copy(name = None)),
+        Rcpt(box.copy(name = None)),
         Vrfy(domain),
         Data,
         Rset,


### PR DESCRIPTION
Add support for email body with alternative content

email sample
```
val email = Email.mime(
     from"user1@mydomain.tld",
     to"user1@example.com",
     subject"привет",
     Body.Alternative(List(Body.Utf8("hi there3"), Body.Ascii("hi there2")))
)```